### PR TITLE
fix windows error on `std::os::unix::ffi` and `as_os_str().as_bytes()`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,10 @@
 use std::fs;
+#[cfg(target_os = "linux")]
 use std::os::unix::ffi::OsStrExt;
+
+#[cfg(target_os = "windows")]
+use std::os::windows::ffi::OsStrExt;
+
 use std::path::PathBuf;
 
 use anstyle::*;
@@ -80,7 +85,13 @@ fn main() -> anyhow::Result<()> {
 
         let path = file.path();
 
+        #[cfg(target_os = "linux")]
         if re.is_some_and(|re| re.find(path.as_os_str().as_bytes()).is_some()) {
+            continue;
+        }
+
+        #[cfg(target_os = "windows")]
+        if re.is_some_and(|re| re.find(path.as_os_str().as_encoded_bytes()).is_some()) {
             continue;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use std::fs;
-#[cfg(target_os = "linux")]
+#[cfg(target_os = "unix")]
 use std::os::unix::ffi::OsStrExt;
 
 #[cfg(target_os = "windows")]
@@ -85,7 +85,7 @@ fn main() -> anyhow::Result<()> {
 
         let path = file.path();
 
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(target_os = "unix"))]
         if re.is_some_and(|re| re.find(path.as_os_str().as_bytes()).is_some()) {
             continue;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ fn main() -> anyhow::Result<()> {
 
         let path = file.path();
 
-        #[cfg(target_os = "unix"))]
+        #[cfg(target_os = "unix")]
         if re.is_some_and(|re| re.find(path.as_os_str().as_bytes()).is_some()) {
             continue;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ fn main() -> anyhow::Result<()> {
 
         let path = file.path();
 
-        #[cfg(target_os = "linux")]
+        #[cfg(not(target_os = "windows"))]
         if re.is_some_and(|re| re.find(path.as_os_str().as_bytes()).is_some()) {
             continue;
         }


### PR DESCRIPTION
added the `cfg target_os` attribute,for windows support

[streamable video: https://streamable.com/n7gwjp](https://streamable.com/n7gwjp)
